### PR TITLE
Change NVIDIA Download Server to US

### DIFF
--- a/overlay/etc/cont-init.d/60-configure_gpu_driver.sh
+++ b/overlay/etc/cont-init.d/60-configure_gpu_driver.sh
@@ -38,7 +38,7 @@ function download_driver {
 
     if [[ ! -f "${USER_HOME:?}/Downloads/NVIDIA_${nvidia_host_driver_version:?}.run" ]]; then
         print_step_header "Downloading driver v${nvidia_host_driver_version:?}"
-        driver_url="http://download.nvidia.com/XFree86/Linux-x86_64/${nvidia_host_driver_version:?}/NVIDIA-Linux-x86_64-${nvidia_host_driver_version:?}.run"
+        driver_url="http://us.download.nvidia.com/XFree86/Linux-x86_64/${nvidia_host_driver_version:?}/NVIDIA-Linux-x86_64-${nvidia_host_driver_version:?}.run"
         if wget --spider --quiet "${driver_url:?}"; then
             wget -q --show-progress --progress=bar:force:noscroll \
                 -O /tmp/NVIDIA.run \


### PR DESCRIPTION
When trying to download NVIDIA Drivers, the script fails. This is due to the nvidia server not serving downloads for some weird reason. Found out on my computer that changing the server to us.download.nvidia.com fixes the issue